### PR TITLE
Fix Github Action Plugin Versions

### DIFF
--- a/.github/workflows/firebase-hosting-merge-development.yml
+++ b/.github/workflows/firebase-hosting-merge-development.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Create Production Build
         run: yarn build
       - name: Archive Production Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: development
           path: build
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: development
           path: build

--- a/.github/workflows/firebase-hosting-merge-development.yml
+++ b/.github/workflows/firebase-hosting-merge-development.yml
@@ -17,9 +17,9 @@ jobs:
       VITE_FIREBASE_APP_ID: "${{ secrets.APP_ID }}"
       VITE_FIREBASE_MEASUREMENT_ID: "${{ secrets.MEASUREMENT_ID }}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install Dependencies
@@ -35,9 +35,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install Dependencies
@@ -49,7 +49,7 @@ jobs:
     needs: [build, lint]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download Artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/firebase-hosting-merge-production.yml
+++ b/.github/workflows/firebase-hosting-merge-production.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Create Production Build
         run: yarn build
       - name: Archive Production Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: production
           path: build
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: production
           path: build

--- a/.github/workflows/firebase-hosting-merge-production.yml
+++ b/.github/workflows/firebase-hosting-merge-production.yml
@@ -17,9 +17,9 @@ jobs:
       VITE_FIREBASE_APP_ID: "${{ secrets.APP_ID }}"
       VITE_FIREBASE_MEASUREMENT_ID: "${{ secrets.MEASUREMENT_ID }}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install Dependencies
@@ -35,9 +35,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install Dependencies
@@ -49,7 +49,7 @@ jobs:
     needs: [build, lint]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download Artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Create Production Build
         run: yarn build
       - name: Archive Production Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: preview
           path: build
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download Artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: preview
           path: build

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -14,9 +14,9 @@ jobs:
       VITE_FIREBASE_APP_ID: "${{ secrets.APP_ID }}"
       VITE_FIREBASE_MEASUREMENT_ID: "${{ secrets.MEASUREMENT_ID }}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install Dependencies
@@ -32,9 +32,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install Dependencies
@@ -47,7 +47,7 @@ jobs:
     needs: [build, lint]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download Artifact
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
# Scope

- Github Action throwing warning that plugin does not support specified node version

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-node@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

# Implementation

- Update checkout / setup-node versions
